### PR TITLE
Update Reader.php

### DIFF
--- a/src/MaxMind/Db/Reader.php
+++ b/src/MaxMind/Db/Reader.php
@@ -84,6 +84,9 @@ class Reader
      */
     public function get($ipAddress)
     {
+        $ipAddresses = explode(",", $ipAddress);
+        $ipAddress = $ipAddresses[0];
+        
         if (func_num_args() != 1) {
             throw new \InvalidArgumentException(
                 'Method takes exactly one argument.'


### PR DESCRIPTION
This PR will alleviate errors (see below) when the ip address parameter is a csv of two ip address, instead of a single address. I would like to just have the first ip address passed along as the parameter for the get function. It might be helpful to do this everywhere, but I was only seeing an error on the get function

Uncaught Exception InvalidArgumentException: "The value "234.166.185.155, 66.102.9.72" is not a valid IP address." at /var/src/platform/vendor/maxmind-db/reader/src/MaxMind/Db/Reader.php line 100
